### PR TITLE
defer FinalizeLogger()

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -321,6 +321,7 @@ func init() {
 		logger.Close()
 		globalLock.Lock()
 		defer globalLock.Unlock()
+		defer FinalizeLogger()
 		lgr = nil
 	}(lgr)
 }


### PR DESCRIPTION
Self-close the logger so the user does not have to.